### PR TITLE
Remove behave_testuser from functional tests

### DIFF
--- a/files/functional-tests/checkboxes_and_mailboxes.feature
+++ b/files/functional-tests/checkboxes_and_mailboxes.feature
@@ -22,7 +22,7 @@ Feature: Checkboxes
   So I can manage more than one email at once
 
   Scenario: User has a list of emails in each mailboxes that needs to be managed
-    When I login
+    Given I'm logged in
     When I mark the first unread email as read
       And I delete the email
     When I select the tag 'trash'

--- a/files/functional-tests/checkboxes_and_mailboxes.feature
+++ b/files/functional-tests/checkboxes_and_mailboxes.feature
@@ -22,7 +22,7 @@ Feature: Checkboxes
   So I can manage more than one email at once
 
   Scenario: User has a list of emails in each mailboxes that needs to be managed
-    Given I login
+    When I login
     When I mark the first unread email as read
       And I delete the email
     When I select the tag 'trash'

--- a/files/functional-tests/checkboxes_and_mailboxes.feature
+++ b/files/functional-tests/checkboxes_and_mailboxes.feature
@@ -22,7 +22,7 @@ Feature: Checkboxes
   So I can manage more than one email at once
 
   Scenario: User has a list of emails in each mailboxes that needs to be managed
-    Given I login as behave-testuser
+    Given I login
     When I mark the first unread email as read
       And I delete the email
     When I select the tag 'trash'

--- a/files/functional-tests/compose_save_draft_and_send.feature
+++ b/files/functional-tests/compose_save_draft_and_send.feature
@@ -21,7 +21,7 @@ Feature: compose mail, save draft and send mail
   So I can review and send them later
 
   Scenario: user composes and email, save the draft, later sends the draft and checks the sent message
-    Given I login
+    When I login
     When I compose a message to 'pixelated@friends.org'
     When I select the tag 'drafts'
     When I open the first mail in the mail list

--- a/files/functional-tests/compose_save_draft_and_send.feature
+++ b/files/functional-tests/compose_save_draft_and_send.feature
@@ -21,7 +21,7 @@ Feature: compose mail, save draft and send mail
   So I can review and send them later
 
   Scenario: user composes and email, save the draft, later sends the draft and checks the sent message
-    When I login
+    Given I'm logged in
     When I compose a message to 'pixelated@friends.org'
     When I select the tag 'drafts'
     When I open the first mail in the mail list

--- a/files/functional-tests/compose_save_draft_and_send.feature
+++ b/files/functional-tests/compose_save_draft_and_send.feature
@@ -21,7 +21,7 @@ Feature: compose mail, save draft and send mail
   So I can review and send them later
 
   Scenario: user composes and email, save the draft, later sends the draft and checks the sent message
-    Given I login as behave-testuser
+    Given I login
     When I compose a message to 'pixelated@friends.org'
     When I select the tag 'drafts'
     When I open the first mail in the mail list

--- a/files/functional-tests/environment.py
+++ b/files/functional-tests/environment.py
@@ -14,16 +14,14 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Pixelated. If not, see <http://www.gnu.org/licenses/>.
 import os
-from page_objects import SignUpPage, LeapLoginPage
+from page_objects import SignUpPage
 from selenium import webdriver
-from selenium.webdriver.common.by import By
-from steps.common import get_invite_code, RandomUser
-from steps import behave_testuser, behave_password, delete_soledad_server_db, delete_soledad_client_db, signup_url
+from steps.common import RandomUser
 import subprocess
+
 
 def before_all(context):
     set_browser(context)
-    create_behave_user(context)
     context.random_user = RandomUser
 
 
@@ -43,7 +41,6 @@ def after_scenario(context, scenario):
 
 
 def after_all(context):
-    _delete_user(context, behave_testuser())
     _delete_user(context, context.random_user.username)
     if hasattr(context, 'browser'):
         context.browser.quit()
@@ -88,17 +85,3 @@ def set_browser(context):
     context.browser.set_window_size(1280, 1024)
     context.browser.implicitly_wait(10)
     context.browser.set_page_load_timeout(60)
-
-
-def create_behave_user(context):
-    username = behave_testuser()
-    password = behave_password()
-    context.browser.get(signup_url())
-    signup_page = SignUpPage(context)
-    signup_page.wait_until_element_is_visible_by_locator((By.CSS_SELECTOR, 'input#srp_username'))
-    signup_page.enter_username(username)
-    signup_page.enter_password(password)
-    signup_page.enter_password_confirmation(password)
-    signup_page.enter_invite_code(get_invite_code())
-    signup_page.click_signup_button()
-    # context.browser.quit()

--- a/files/functional-tests/page_objects/mail_page.py
+++ b/files/functional-tests/page_objects/mail_page.py
@@ -23,7 +23,7 @@ class MailPage(BasePageObject):
         self._locators = {
             'encrypted_flag': '.security-status__label--encrypted',
             'unencrypted_flag': '.security-status__label--not-encrypted',
-            'undercryptable_flag': '.security-status__label--encryption-error',
+            'undecryptable_flag': '.security-status__label--encryption-error',
             'subject': '#mail-view .subject',
             'body': '#mail-view .bodyArea',
             'tags': '#mail-view .tagsArea .tag',

--- a/files/functional-tests/search_and_destroy.feature
+++ b/files/functional-tests/search_and_destroy.feature
@@ -23,7 +23,7 @@ Feature: search mail and deletion
   So I can manage them
 
   Scenario: User searches for a mail and deletes it
-    When I login
+    Given I'm logged in
     When I search for a mail with the words "mail"
     When I open the first mail in the mail list
     Then I see one or more mails in the search results

--- a/files/functional-tests/search_and_destroy.feature
+++ b/files/functional-tests/search_and_destroy.feature
@@ -23,7 +23,7 @@ Feature: search mail and deletion
   So I can manage them
 
   Scenario: User searches for a mail and deletes it
-    Given I login
+    When I login
     When I search for a mail with the words "mail"
     When I open the first mail in the mail list
     Then I see one or more mails in the search results

--- a/files/functional-tests/search_and_destroy.feature
+++ b/files/functional-tests/search_and_destroy.feature
@@ -23,7 +23,7 @@ Feature: search mail and deletion
   So I can manage them
 
   Scenario: User searches for a mail and deletes it
-    Given I login as behave-testuser
+    Given I login
     When I search for a mail with the words "mail"
     When I open the first mail in the mail list
     Then I see one or more mails in the search results

--- a/files/functional-tests/send_mail.feature
+++ b/files/functional-tests/send_mail.feature
@@ -26,8 +26,7 @@ Feature: send_mail
 
   @unencrypted
   Scenario: user receives an unencrypted email
-    Given there is another user
-    When I send an unencrypted email
+    Given I send an unencrypted email
     And I login
     When I open the unencrypted email
     Then I see a unencrypted email flag
@@ -35,8 +34,7 @@ Feature: send_mail
   @wip
   @undecryptable
   Scenario: user receives an email we cannot decrypt
-    Given there is another user
-    When I send an email encrypted to someone else
+    Given I send an email encrypted to someone else
     And I login
     When I open the undecryptable email
     Then I see a undecryptable flag

--- a/files/functional-tests/send_mail.feature
+++ b/files/functional-tests/send_mail.feature
@@ -19,7 +19,7 @@ Feature: send_mail
 
   @mail_to_myself
   Scenario: user logs in end sends a mail to self
-    When I login
+    Given I'm logged in
     When I send a mail to myself
     When I open the email
     Then I see a encrypted flag
@@ -41,7 +41,7 @@ Feature: send_mail
 
   @logout
   Scenario: user logs out
-    When I login
+    Given I'm logged in
     When I logout
     And I visit the user-agent
     Then I should see a login button

--- a/files/functional-tests/send_mail.feature
+++ b/files/functional-tests/send_mail.feature
@@ -19,16 +19,15 @@ Feature: send_mail
 
   @mail_to_myself
   Scenario: user logs in end sends a mail to self
-    Given I login as behave-testuser
+    Given I login
     When I send a mail to myself
-#    And I see that the mail was sent
     When I open the email
     Then I see a encrypted flag
 
   @unencrypted
   Scenario: user receives an unencrypted email
     Given I send an unencrypted email
-    And I login as behave-testuser
+    And I login
     When I open the unencrypted email
     Then I see a unencrypted email flag
 
@@ -36,13 +35,13 @@ Feature: send_mail
   @undecryptable
   Scenario: user receives an email we cannot decrypt
     Given I send an email encrypted to someone else
-    And I login as behave-testuser
+    And I login
     When I open the undecryptable email
     Then I see a undecryptable flag
 
   @logout
-  Scenario: behave-testuser logs out
-    Given I login as behave-testuser
+  Scenario: user logs out
+    Given I login
     When I logout
     And I visit the user-agent
     Then I should see a login button

--- a/files/functional-tests/send_mail.feature
+++ b/files/functional-tests/send_mail.feature
@@ -19,7 +19,7 @@ Feature: send_mail
 
   @mail_to_myself
   Scenario: user logs in end sends a mail to self
-    Given I login
+    When I login
     When I send a mail to myself
     When I open the email
     Then I see a encrypted flag
@@ -41,7 +41,7 @@ Feature: send_mail
 
   @logout
   Scenario: user logs out
-    Given I login
+    When I login
     When I logout
     And I visit the user-agent
     Then I should see a login button

--- a/files/functional-tests/send_mail.feature
+++ b/files/functional-tests/send_mail.feature
@@ -27,7 +27,7 @@ Feature: send_mail
   @unencrypted
   Scenario: user receives an unencrypted email
     Given I send an unencrypted email
-    And I login
+    When I login
     When I open the unencrypted email
     Then I see a unencrypted email flag
 
@@ -35,7 +35,7 @@ Feature: send_mail
   @undecryptable
   Scenario: user receives an email we cannot decrypt
     Given I send an email encrypted to someone else
-    And I login
+    When I login
     When I open the undecryptable email
     Then I see a undecryptable flag
 

--- a/files/functional-tests/send_mail.feature
+++ b/files/functional-tests/send_mail.feature
@@ -26,7 +26,8 @@ Feature: send_mail
 
   @unencrypted
   Scenario: user receives an unencrypted email
-    Given I send an unencrypted email
+    Given there is another user
+    When I send an unencrypted email
     And I login
     When I open the unencrypted email
     Then I see a unencrypted email flag
@@ -34,7 +35,8 @@ Feature: send_mail
   @wip
   @undecryptable
   Scenario: user receives an email we cannot decrypt
-    Given I send an email encrypted to someone else
+    Given there is another user
+    When I send an email encrypted to someone else
     And I login
     When I open the undecryptable email
     Then I see a undecryptable flag

--- a/files/functional-tests/steps/__init__.py
+++ b/files/functional-tests/steps/__init__.py
@@ -51,18 +51,6 @@ def leap_login_url():
     return url_home() + '/login'
 
 
-def behave_email():
-    return '%s@%s' % (behave_testuser(), hostname)
-
-
-def behave_password():
-    return 'Eido6aeg3za9ooNiekiemahm'
-
-
-def behave_testuser():
-    return 'behaveuser'
-
-
 def _netrc_couch_credentials():
     with open('/etc/couchdb/couchdb.netrc', 'r') as netrc:
         netrc_line = netrc.readline().strip().split(' ')

--- a/files/functional-tests/steps/account.py
+++ b/files/functional-tests/steps/account.py
@@ -38,6 +38,7 @@ def step_impl(context):
 
 @when(u'I login')
 def step_impl(context):
+    context.browser.get(login_url())
     login_page = LoginPage(context)
     login_page.enter_username(context.random_user.username).enter_password(context.random_user.password).login()
     login_page.wait_interstitial_page()

--- a/files/functional-tests/steps/account.py
+++ b/files/functional-tests/steps/account.py
@@ -36,6 +36,7 @@ def step_impl(context):
     context.browser.find_element_by_name('login')
 
 
+@given(u'I\'m logged in')
 @when(u'I login')
 def step_impl(context):
     context.browser.get(login_url())

--- a/files/functional-tests/steps/account.py
+++ b/files/functional-tests/steps/account.py
@@ -78,6 +78,13 @@ def step_impl(context):
     signup_page.enter_invite_code(get_invite_code())
     signup_page.click_signup_button()
 
+
+@then(u'I see the control-panel')
+def step_impl(context):
+    controlpanel_page = ControlPanelPage(context)
+    controlpanel_page.is_control_panel_home()
+
+
 @given(u'there is another user')
 def step_impl(context):
     context.browser.get(signup_url())
@@ -88,9 +95,5 @@ def step_impl(context):
     signup_page.enter_password_confirmation(context.external_user.password)
     signup_page.enter_invite_code(get_invite_code())
     signup_page.click_signup_button()
-
-
-@then(u'I see the control-panel')
-def step_impl(context):
     controlpanel_page = ControlPanelPage(context)
     controlpanel_page.is_control_panel_home()

--- a/files/functional-tests/steps/account.py
+++ b/files/functional-tests/steps/account.py
@@ -83,17 +83,3 @@ def step_impl(context):
 def step_impl(context):
     controlpanel_page = ControlPanelPage(context)
     controlpanel_page.is_control_panel_home()
-
-
-@given(u'there is another user')
-def step_impl(context):
-    context.browser.get(signup_url())
-    context.external_user = RandomUser
-    signup_page = SignUpPage(context)
-    signup_page.enter_username(context.external_user.username)
-    signup_page.enter_password(context.external_user.password)
-    signup_page.enter_password_confirmation(context.external_user.password)
-    signup_page.enter_invite_code(get_invite_code())
-    signup_page.click_signup_button()
-    controlpanel_page = ControlPanelPage(context)
-    controlpanel_page.is_control_panel_home()

--- a/files/functional-tests/steps/account.py
+++ b/files/functional-tests/steps/account.py
@@ -78,6 +78,17 @@ def step_impl(context):
     signup_page.enter_invite_code(get_invite_code())
     signup_page.click_signup_button()
 
+@given(u'there is another user')
+def step_impl(context):
+    context.browser.get(signup_url())
+    context.external_user = RandomUser
+    signup_page = SignUpPage(context)
+    signup_page.enter_username(context.external_user.username)
+    signup_page.enter_password(context.external_user.password)
+    signup_page.enter_password_confirmation(context.external_user.password)
+    signup_page.enter_invite_code(get_invite_code())
+    signup_page.click_signup_button()
+
 
 @then(u'I see the control-panel')
 def step_impl(context):

--- a/files/functional-tests/steps/common.py
+++ b/files/functional-tests/steps/common.py
@@ -65,11 +65,11 @@ def save_source(context, filename='/tmp/source.html'):
 def send_external_email(context, subject, body):
     msg = MIMEText(body)
     msg['Subject'] = subject
-    msg['From'] = context.external_user.email
+    msg['From'] = context.random_user.email
     msg['To'] = context.random_user.email
 
     s = smtplib.SMTP(hostname)
-    s.sendmail(context.external_user.email, [context.random_user.email], msg.as_string())
+    s.sendmail(context.random_user.email, [context.random_user.email], msg.as_string())
     s.quit()
 
 

--- a/files/functional-tests/steps/common.py
+++ b/files/functional-tests/steps/common.py
@@ -65,11 +65,11 @@ def save_source(context, filename='/tmp/source.html'):
 def send_external_email(context, subject, body):
     msg = MIMEText(body)
     msg['Subject'] = subject
-    msg['From'] = context.random_user.email
-    msg['To'] = context.external_user.email
+    msg['From'] = context.external_user.email
+    msg['To'] = context.random_user.email
 
     s = smtplib.SMTP(hostname)
-    s.sendmail(context.random_user.email, [context.external_user.email], msg.as_string())
+    s.sendmail(context.external_user.email, [context.random_user.email], msg.as_string())
     s.quit()
 
 

--- a/files/functional-tests/steps/common.py
+++ b/files/functional-tests/steps/common.py
@@ -20,7 +20,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
 from email.mime.text import MIMEText
-from steps import behave_email, hostname
+from steps import hostname
 
 import string
 import random
@@ -33,6 +33,7 @@ MAX_WAIT_IN_S = 120
 class RandomUser(object):
     username = 'test_user_' + ''.join(random.choice(string.lowercase) for i in range(16))
     password = ''.join(random.choice(string.lowercase) for i in range(16))
+    email = '%s@%s' % (username, hostname)
 
 
 def get_invite_code():
@@ -64,11 +65,11 @@ def save_source(context, filename='/tmp/source.html'):
 def send_external_email(subject, body):
     msg = MIMEText(body)
     msg['Subject'] = subject
-    msg['From'] = behave_email()
-    msg['To'] = behave_email()
+    msg['From'] = RandomUser.email
+    msg['To'] = RandomUser.email
 
     s = smtplib.SMTP(hostname)
-    s.sendmail(behave_email(), [behave_email()], msg.as_string())
+    s.sendmail(RandomUser.email, [RandomUser.email], msg.as_string())
     s.quit()
 
 

--- a/files/functional-tests/steps/common.py
+++ b/files/functional-tests/steps/common.py
@@ -62,14 +62,14 @@ def save_source(context, filename='/tmp/source.html'):
         out.write(context.browser.page_source.encode('utf8'))
 
 
-def send_external_email(subject, body):
+def send_external_email(context, subject, body):
     msg = MIMEText(body)
     msg['Subject'] = subject
-    msg['From'] = RandomUser.email
-    msg['To'] = RandomUser.email
+    msg['From'] = context.random_user.email
+    msg['To'] = context.external_user.email
 
     s = smtplib.SMTP(hostname)
-    s.sendmail(RandomUser.email, [RandomUser.email], msg.as_string())
+    s.sendmail(context.random_user.email, [context.external_user.email], msg.as_string())
     s.quit()
 
 

--- a/files/functional-tests/steps/common.py
+++ b/files/functional-tests/steps/common.py
@@ -77,10 +77,3 @@ def open_email(context, subject):
     locator = '//ul[@id="mail-list"]//*[contains(.,"%s")]/parent::a' % subject
     wait_long_until_element_is_visible_by_locator(context, (By.XPATH, locator)).click()
 
-
-
-
-
-
-
-

--- a/files/functional-tests/steps/mail_list.py
+++ b/files/functional-tests/steps/mail_list.py
@@ -20,7 +20,9 @@ from ..page_objects import PixelatedPage
 from ..page_objects import MailList
 from ..page_objects import MailListActions
 
-
+#FROM USER AGENT REPO
+from selenium.common.exceptions import NoSuchElementException
+from time import sleep
 
 
 @then('I see the email on the mail list')
@@ -28,10 +30,6 @@ def impl(context):
     pixelated_page = PixelatedPage(context)
     pixelated_page.is_mail_on_list(context.pixelated_email, pixelated_page.random_subject(), 240)
 
-
-#FROM USER AGENT REPO
-from selenium.common.exceptions import NoSuchElementException
-from time import sleep
 
 def find_current_mail(context):
     return context.browser.find_element_by_id(context.current_mail_id)

--- a/files/functional-tests/steps/send_mail.py
+++ b/files/functional-tests/steps/send_mail.py
@@ -57,28 +57,28 @@ def step_impl(context):
 @when(u'I open the email')
 def step_impl(context):
     subject = 'email to myself %s' % random_subject()
-    behave_user = behave_testuser()
+    email_from = RandomUser.username
 
     maillist = MailList(context)
-    maillist.select_mail(behave_user, subject)
+    maillist.select_mail(email_from, subject)
 
 
 @when(u'I open the undecryptable email')
 def step_impl(context):
     subject = 'undecryptable email %s' % random_subject()
-    behave_user = behave_testuser()
+    email_from = RandomUser.username
 
     maillist = MailList(context)
-    maillist.select_mail(behave_user, subject)
+    maillist.select_mail(email_from, subject)
 
 
 @when(u'I open the unencrypted email')
 def step_impl(context):
     subject =  'unencrypted email %s' % random_subject()
-    behave_user = behave_testuser()
+    email_from = RandomUser.username
 
     maillist = MailList(context)
-    maillist.select_mail(behave_user, subject)
+    maillist.select_mail(email_from, subject)
 
 
 @then(u'I see a encrypted flag')

--- a/files/functional-tests/steps/send_mail.py
+++ b/files/functional-tests/steps/send_mail.py
@@ -25,19 +25,9 @@ from behave import *
 from common import *
 
 
-@given(u'I send an unencrypted email')
-def step_impl(context):
-    send_external_email('unencrypted email %s' %random_subject(), 'some body')
-
-
-@given(u'I send an email encrypted to someone else')
-def step_impl(context):
-    send_external_email('undecryptable email %s' %random_subject(), encrypted_body())
-
-
 @when(u'I send a mail to myself')
 def step_impl(context):
-    email_to = RandomUser.email
+    email_to = context.random_user.email
     compose_box = ComposeBox(context)
     maillist_actions = MailListActions(context)
 
@@ -48,34 +38,10 @@ def step_impl(context):
     compose_box.send_mail()
 
 
-@when(u'I see that the mail was sent')
-def step_impl(context):
-    notification = Notification(context)
-    notification.wait_for_notification("message_sent")
-
-
 @when(u'I open the email')
 def step_impl(context):
     subject = 'email to myself %s' % random_subject()
-    email_from = RandomUser.username
-
-    maillist = MailList(context)
-    maillist.select_mail(email_from, subject)
-
-
-@when(u'I open the undecryptable email')
-def step_impl(context):
-    subject = 'undecryptable email %s' % random_subject()
-    email_from = RandomUser.username
-
-    maillist = MailList(context)
-    maillist.select_mail(email_from, subject)
-
-
-@when(u'I open the unencrypted email')
-def step_impl(context):
-    subject =  'unencrypted email %s' % random_subject()
-    email_from = RandomUser.username
+    email_from = context.random_user.username
 
     maillist = MailList(context)
     maillist.select_mail(email_from, subject)
@@ -87,16 +53,52 @@ def step_impl(context):
     mail_page.check_mail_flag('encrypted_flag')
 
 
-@then(u'I see a unencrypted email flag')
+@when(u'I see that the mail was sent')
 def step_impl(context):
-    mail_page = MailPage(context)
-    mail_page.check_mail_flag('unencrypted_flag')
+    notification = Notification(context)
+    notification.wait_for_notification("message_sent")
+
+
+@given(u'I send an email encrypted to someone else')
+def step_impl(context):
+    context.external_user = RandomUser
+    send_external_email(context, 'undecryptable email %s' %random_subject(), encrypted_body())
+
+
+@when(u'I open the undecryptable email')
+def step_impl(context):
+    subject = 'undecryptable email %s' % random_subject()
+    email_from = context.external_user.username
+
+    maillist = MailList(context)
+    maillist.select_mail(email_from, subject)
 
 
 @then(u'I see a undecryptable flag')
 def step_impl(context):
     mail_page = MailPage(context)
     mail_page.check_mail_flag('undercryptable_flag')
+
+
+@given(u'I send an unencrypted email')
+def step_impl(context):
+    context.external_user = RandomUser
+    send_external_email(context, 'unencrypted email %s' %random_subject(), 'some body')
+
+
+@when(u'I open the unencrypted email')
+def step_impl(context):
+    subject =  'unencrypted email %s' % random_subject()
+    email_from = context.external_user.username
+
+    maillist = MailList(context)
+    maillist.select_mail(email_from, subject)
+
+
+@then(u'I see a unencrypted email flag')
+def step_impl(context):
+    mail_page = MailPage(context)
+    mail_page.check_mail_flag('unencrypted_flag')
 
 
 def encrypted_body():

--- a/files/functional-tests/steps/send_mail.py
+++ b/files/functional-tests/steps/send_mail.py
@@ -76,7 +76,7 @@ def step_impl(context):
 @then(u'I see a undecryptable flag')
 def step_impl(context):
     mail_page = MailPage(context)
-    mail_page.check_mail_flag('undercryptable_flag')
+    mail_page.check_mail_flag('undecryptable_flag')
 
 
 @when(u'I send an unencrypted email')

--- a/files/functional-tests/steps/send_mail.py
+++ b/files/functional-tests/steps/send_mail.py
@@ -28,6 +28,7 @@ from common import *
 @when(u'I send a mail to myself')
 def step_impl(context):
     email_to = context.random_user.email
+    print("-----------------Random user email: ", context.random_user.email)
     compose_box = ComposeBox(context)
     maillist_actions = MailListActions(context)
 

--- a/files/functional-tests/steps/send_mail.py
+++ b/files/functional-tests/steps/send_mail.py
@@ -59,7 +59,7 @@ def step_impl(context):
     notification.wait_for_notification("message_sent")
 
 
-@when(u'I send an email encrypted to someone else')
+@given(u'I send an email encrypted to someone else')
 def step_impl(context):
     send_external_email(context, 'undecryptable email %s' %random_subject(), encrypted_body())
 
@@ -67,7 +67,7 @@ def step_impl(context):
 @when(u'I open the undecryptable email')
 def step_impl(context):
     subject = 'undecryptable email %s' % random_subject()
-    email_from = context.external_user.username
+    email_from = context.random_user.username
 
     maillist = MailList(context)
     maillist.select_mail(email_from, subject)
@@ -79,7 +79,7 @@ def step_impl(context):
     mail_page.check_mail_flag('undecryptable_flag')
 
 
-@when(u'I send an unencrypted email')
+@given(u'I send an unencrypted email')
 def step_impl(context):
     send_external_email(context, 'unencrypted email %s' %random_subject(), 'some body')
 
@@ -87,7 +87,7 @@ def step_impl(context):
 @when(u'I open the unencrypted email')
 def step_impl(context):
     subject =  'unencrypted email %s' % random_subject()
-    email_from = context.external_user.username
+    email_from = context.random_user.username
 
     maillist = MailList(context)
     maillist.select_mail(email_from, subject)

--- a/files/functional-tests/steps/send_mail.py
+++ b/files/functional-tests/steps/send_mail.py
@@ -60,9 +60,8 @@ def step_impl(context):
     notification.wait_for_notification("message_sent")
 
 
-@given(u'I send an email encrypted to someone else')
+@when(u'I send an email encrypted to someone else')
 def step_impl(context):
-    context.external_user = RandomUser
     send_external_email(context, 'undecryptable email %s' %random_subject(), encrypted_body())
 
 
@@ -81,9 +80,8 @@ def step_impl(context):
     mail_page.check_mail_flag('undercryptable_flag')
 
 
-@given(u'I send an unencrypted email')
+@when(u'I send an unencrypted email')
 def step_impl(context):
-    context.external_user = RandomUser
     send_external_email(context, 'unencrypted email %s' %random_subject(), 'some body')
 
 

--- a/files/functional-tests/steps/send_mail.py
+++ b/files/functional-tests/steps/send_mail.py
@@ -68,7 +68,7 @@ def step_impl(context):
 @when(u'I open the undecryptable email')
 def step_impl(context):
     subject = 'undecryptable email %s' % random_subject()
-    email_from = context.external_user.username
+    email_from = context.random_user.username
 
     maillist = MailList(context)
     maillist.select_mail(email_from, subject)
@@ -88,7 +88,7 @@ def step_impl(context):
 @when(u'I open the unencrypted email')
 def step_impl(context):
     subject =  'unencrypted email %s' % random_subject()
-    email_from = context.external_user.username
+    email_from = context.random_user.username
 
     maillist = MailList(context)
     maillist.select_mail(email_from, subject)

--- a/files/functional-tests/steps/send_mail.py
+++ b/files/functional-tests/steps/send_mail.py
@@ -23,15 +23,6 @@ from ..page_objects import Notification
 
 from behave import *
 from common import *
-from steps import behave_email, behave_password, behave_testuser, login_url
-
-
-@given(u'I login as behave-testuser')
-def step_impl(context):
-    context.browser.get(login_url())
-    login_page = LoginPage(context)
-    login_page.enter_username(behave_testuser()).enter_password(behave_password()).login()
-    login_page.wait_interstitial_page()
 
 
 @given(u'I send an unencrypted email')
@@ -46,7 +37,7 @@ def step_impl(context):
 
 @when(u'I send a mail to myself')
 def step_impl(context):
-    email_to = behave_email()
+    email_to = RandomUser.email
     compose_box = ComposeBox(context)
     maillist_actions = MailListActions(context)
 

--- a/files/functional-tests/steps/send_mail.py
+++ b/files/functional-tests/steps/send_mail.py
@@ -28,7 +28,6 @@ from common import *
 @when(u'I send a mail to myself')
 def step_impl(context):
     email_to = context.random_user.email
-    print("-----------------Random user email: ", context.random_user.email)
     compose_box = ComposeBox(context)
     maillist_actions = MailListActions(context)
 
@@ -68,7 +67,7 @@ def step_impl(context):
 @when(u'I open the undecryptable email')
 def step_impl(context):
     subject = 'undecryptable email %s' % random_subject()
-    email_from = context.random_user.username
+    email_from = context.external_user.username
 
     maillist = MailList(context)
     maillist.select_mail(email_from, subject)
@@ -88,7 +87,7 @@ def step_impl(context):
 @when(u'I open the unencrypted email')
 def step_impl(context):
     subject =  'unencrypted email %s' % random_subject()
-    email_from = context.random_user.username
+    email_from = context.external_user.username
 
     maillist = MailList(context)
     maillist.select_mail(email_from, subject)

--- a/files/functional-tests/tag_and_reply.feature
+++ b/files/functional-tests/tag_and_reply.feature
@@ -21,7 +21,7 @@ Feature: Tag and reply
   So that I can easily find them
 
   Scenario: User tags a mail, replies to it then checks that mail is in the right tag
-    Given I login
+    When I login
     When I open the first mail in the 'inbox'
     When I add the tag 'website' to that mail
     Then I see that mail under the 'website' tag

--- a/files/functional-tests/tag_and_reply.feature
+++ b/files/functional-tests/tag_and_reply.feature
@@ -21,7 +21,7 @@ Feature: Tag and reply
   So that I can easily find them
 
   Scenario: User tags a mail, replies to it then checks that mail is in the right tag
-    When I login
+    Given I'm logged in
     When I open the first mail in the 'inbox'
     When I add the tag 'website' to that mail
     Then I see that mail under the 'website' tag

--- a/files/functional-tests/tag_and_reply.feature
+++ b/files/functional-tests/tag_and_reply.feature
@@ -21,8 +21,7 @@ Feature: Tag and reply
   So that I can easily find them
 
   Scenario: User tags a mail, replies to it then checks that mail is in the right tag
-#    Given I have a mail in my inbox
-    Given I login as behave-testuser
+    Given I login
     When I open the first mail in the 'inbox'
     When I add the tag 'website' to that mail
     Then I see that mail under the 'website' tag


### PR DESCRIPTION
Our functional tests were dependent on a static user name "behave_testuser", which quite frequently led to inconsistencies in our pipeline. Due to delays in deleting this test user on tear down, sometimes this user had an empty key that wouldn't be deleted until a few hours later. 

To avoid breaking our tests for this reason, we decided to always use a random user in our tests. These changes are for that.