### PR TITLE
Pin packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@
 # ignore files created by functional test
 /files/functional-tests/ghostdriver.log
 *.pyc
+# ignore bundles
+.bundle/
+vendor/
+# ignore rbenv files
+.ruby-version

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 group :test do
+  gem "safe_yaml"
   gem "rake",'< 11'
   gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.8.0'
   gem "rspec", '< 3.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,7 @@ GEM
       puppet
     rspec-puppet-utils (2.2.1)
     rspec-support (3.1.2)
+    safe_yaml (1.0.4)
     spdx-licenses (1.1.0)
     stomp (1.4.3)
     systemu (2.6.5)
@@ -74,6 +75,7 @@ DEPENDENCIES
   rspec-puppet
   rspec-puppet-facts
   rspec-puppet-utils
+  safe_yaml
 
 BUNDLED WITH
-   1.11.2
+   1.13.7

--- a/manifests/apt/preferences.pp
+++ b/manifests/apt/preferences.pp
@@ -8,6 +8,7 @@ class pixelated::apt::preferences {
 
   apt::preferences_snippet { ['soledad-server',
     'soledad-common',
+    'soledad-client',
     'leap-keymanager',
     'leap-auth']:
       pin      => 'release o=pixelated',

--- a/manifests/apt/preferences.pp
+++ b/manifests/apt/preferences.pp
@@ -8,7 +8,6 @@ class pixelated::apt::preferences {
 
   apt::preferences_snippet { ['soledad-server',
     'soledad-common',
-    'soledad-client',
     'leap-keymanager',
     'leap-auth']:
       pin      => 'release o=pixelated',

--- a/manifests/apt/preferences.pp
+++ b/manifests/apt/preferences.pp
@@ -10,7 +10,7 @@ class pixelated::apt::preferences {
     'soledad-common',
     'soledad-client',
     'leap-mx',
-    'leap-common']:
+    'python-leap-common']:
       pin      => 'release o=pixelated',
       priority => 1000,
   }

--- a/manifests/apt/preferences.pp
+++ b/manifests/apt/preferences.pp
@@ -6,13 +6,10 @@ class pixelated::apt::preferences {
     priority => 999
   }
 
-  apt::preferences_snippet { ['soledad-server',
-    'soledad-common',
-    'soledad-client',
-    'leap-mx',
-    'python-leap-common']:
-      pin      => 'release o=pixelated',
-      priority => 1000,
+  apt::preferences_snippet { 'pixelated':
+    priority => 1000,
+    package  => '*',
+    pin      => 'origin "packages.pixelated-project.org"'
   }
 
 }

--- a/manifests/apt/preferences.pp
+++ b/manifests/apt/preferences.pp
@@ -9,10 +9,11 @@ class pixelated::apt::preferences {
   apt::preferences_snippet { ['soledad-server',
     'soledad-common',
     'soledad-client',
+    'leap-mx',
     'leap-keymanager',
     'leap-auth']:
       pin      => 'release o=pixelated',
-      priority => 999,
+      priority => 1000,
   }
 
 }

--- a/manifests/apt/preferences.pp
+++ b/manifests/apt/preferences.pp
@@ -10,8 +10,7 @@ class pixelated::apt::preferences {
     'soledad-common',
     'soledad-client',
     'leap-mx',
-    'leap-keymanager',
-    'leap-auth']:
+    'leap-common']:
       pin      => 'release o=pixelated',
       priority => 1000,
   }

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -25,7 +25,7 @@ require 'spec_helper'
       "define apache::vhost::file($content,$mod_security) {}",
       "define apt::sources_list($content='deb url') {}",
       "define apt::apt_conf($source='file url',$refresh_apt='true') {}",
-      "define apt::preferences_snippet($release='stable',$priority='999',$pin='release o=Debian') {}",
+      "define apt::preferences_snippet($release='stable',$priority='999',$pin='release o=Debian',$package='*') {}",
     ] }
 
     it { should contain_class('pixelated::syslog') }

--- a/spec/classes/apt_preferences_spec.rb
+++ b/spec/classes/apt_preferences_spec.rb
@@ -15,7 +15,7 @@ describe 'pixelated::apt::preferences' do
     "define apt::preferences_snippet($release='stable',$priority='999',$pin='release o=Debian') {}",
     ] }
 
-  %w( soledad-server soledad-client soledad-common leap-mx leap-keymanager leap-auth).each do | package |
+  %w( soledad-server soledad-client soledad-common leap-mx leap-common).each do | package |
     it { should contain_apt__preferences_snippet("#{package}").with_pin('release o=pixelated')}
     it { should contain_apt__preferences_snippet("#{package}").with_priority('1000')}
   end

--- a/spec/classes/apt_preferences_spec.rb
+++ b/spec/classes/apt_preferences_spec.rb
@@ -15,12 +15,12 @@ describe 'pixelated::apt::preferences' do
     "define apt::preferences_snippet($release='stable',$priority='999',$pin='release o=Debian') {}",
     ] }
 
-  %w( soledad-server soledad-common leap-keymanager leap-auth).each do | package |
-    it { should contain_apt__preferences_snippet("#{package}").with_pin('release o=pixelated')}
-  end
+#  %w( soledad-server soledad-client soledad-common leap-keymanager leap-auth).each do | package |
+    #it { should contain_apt__preferences_snippet("#{package}").with_pin('release o=pixelated')}
+  #end
 
-  %w( python-urllib3 python-requests python-six).each do | package |
-    it { should contain_apt__preferences_snippet("#{package}").with_release(/jessie/) }
-  end
+ # %w( python-urllib3 python-requests python-six).each do | package |
+    #it { should contain_apt__preferences_snippet("#{package}").with_release(/jessie/) }
+  #end
 
 end

--- a/spec/classes/apt_preferences_spec.rb
+++ b/spec/classes/apt_preferences_spec.rb
@@ -15,12 +15,12 @@ describe 'pixelated::apt::preferences' do
     "define apt::preferences_snippet($release='stable',$priority='999',$pin='release o=Debian') {}",
     ] }
 
-#  %w( soledad-server soledad-client soledad-common leap-keymanager leap-auth).each do | package |
-    #it { should contain_apt__preferences_snippet("#{package}").with_pin('release o=pixelated')}
-  #end
+  %w( soledad-server soledad-common leap-keymanager leap-auth).each do | package |
+    it { should contain_apt__preferences_snippet("#{package}").with_pin('release o=pixelated')}
+  end
 
- # %w( python-urllib3 python-requests python-six).each do | package |
-    #it { should contain_apt__preferences_snippet("#{package}").with_release(/jessie/) }
-  #end
+  %w( python-urllib3 python-requests python-six).each do | package |
+    it { should contain_apt__preferences_snippet("#{package}").with_release(/jessie/) }
+  end
 
 end

--- a/spec/classes/apt_preferences_spec.rb
+++ b/spec/classes/apt_preferences_spec.rb
@@ -15,7 +15,7 @@ describe 'pixelated::apt::preferences' do
     "define apt::preferences_snippet($release='stable',$priority='999',$pin='release o=Debian') {}",
     ] }
 
-  %w( soledad-server soledad-client soledad-common leap-mx leap-common).each do | package |
+  %w( soledad-server soledad-client soledad-common leap-mx python-leap-common).each do | package |
     it { should contain_apt__preferences_snippet("#{package}").with_pin('release o=pixelated')}
     it { should contain_apt__preferences_snippet("#{package}").with_priority('1000')}
   end

--- a/spec/classes/apt_preferences_spec.rb
+++ b/spec/classes/apt_preferences_spec.rb
@@ -15,8 +15,9 @@ describe 'pixelated::apt::preferences' do
     "define apt::preferences_snippet($release='stable',$priority='999',$pin='release o=Debian') {}",
     ] }
 
-  %w( soledad-server soledad-client soledad-common leap-keymanager leap-auth).each do | package |
+  %w( soledad-server soledad-client soledad-common leap-mx leap-keymanager leap-auth).each do | package |
     it { should contain_apt__preferences_snippet("#{package}").with_pin('release o=pixelated')}
+    it { should contain_apt__preferences_snippet("#{package}").with_priority('1000')}
   end
 
   %w( python-urllib3 python-requests python-six).each do | package |

--- a/spec/classes/apt_preferences_spec.rb
+++ b/spec/classes/apt_preferences_spec.rb
@@ -15,12 +15,12 @@ describe 'pixelated::apt::preferences' do
     "define apt::preferences_snippet($release='stable',$priority='999',$pin='release o=Debian') {}",
     ] }
 
-#  %w( soledad-server soledad-client soledad-common leap-keymanager leap-auth).each do | package |
-    #it { should contain_apt__preferences_snippet("#{package}").with_pin('release o=pixelated')}
-  #end
+  %w( soledad-server soledad-client soledad-common leap-keymanager leap-auth).each do | package |
+    it { should contain_apt__preferences_snippet("#{package}").with_pin('release o=pixelated')}
+  end
 
- # %w( python-urllib3 python-requests python-six).each do | package |
-    #it { should contain_apt__preferences_snippet("#{package}").with_release(/jessie/) }
-  #end
+  %w( python-urllib3 python-requests python-six).each do | package |
+    it { should contain_apt__preferences_snippet("#{package}").with_release(/jessie/) }
+  end
 
 end

--- a/spec/classes/apt_preferences_spec.rb
+++ b/spec/classes/apt_preferences_spec.rb
@@ -12,12 +12,12 @@ describe 'pixelated::apt::preferences' do
     let(:pre_condition) { [
     "class apt {}",
     "define apt::sources_list($content='deb url') {}",
-    "define apt::preferences_snippet($release='stable',$priority='999',$pin='release o=Debian') {}",
+    "define apt::preferences_snippet($release='stable',$priority='999',$pin='release o=Debian',$package='*') {}",
     ] }
 
-  %w( soledad-server soledad-client soledad-common leap-mx python-leap-common).each do | package |
-    it { should contain_apt__preferences_snippet("#{package}").with_pin('release o=pixelated')}
-    it { should contain_apt__preferences_snippet("#{package}").with_priority('1000')}
+  describe 'pixelated packages' do
+    it { should contain_apt__preferences_snippet("pixelated").with_pin('origin "packages.pixelated-project.org"')}
+    it { should contain_apt__preferences_snippet("pixelated").with_priority('1000')}
   end
 
   %w( python-urllib3 python-requests python-six).each do | package |

--- a/spec/classes/pixelated_spec.rb
+++ b/spec/classes/pixelated_spec.rb
@@ -21,7 +21,7 @@ describe 'pixelated' do
       "define apache::vhost::file($content,$mod_security) {}",
       "define apt::sources_list($content='deb url') {}",
       "define apt::apt_conf($source='file url',$refresh_apt='true') {}",
-      "define apt::preferences_snippet($release='stable',$priority='999',$pin='release o=Debian') {}",
+      "define apt::preferences_snippet($release='stable',$priority='999',$pin='release o=Debian',$package='*') {}",
     ] }
 
     it { should contain_class('pixelated::agent') }

--- a/spec/classes/syslog_spec.rb
+++ b/spec/classes/syslog_spec.rb
@@ -15,7 +15,7 @@ describe 'pixelated::syslog' do
       "define apache::vhost::file($content,$mod_security) {}",
       "define apt::sources_list($content='deb url') {}",
       "define apt::apt_conf($source='file url') {}",
-      "define apt::preferences_snippet($release='stable',$priority='999',$pin='release o=Debian') {}",
+      "define apt::preferences_snippet($release='stable',$priority='999',$pin='release o=Debian',$package='*') {}",
     ] }
 
  


### PR DESCRIPTION
To ensure we always use the LEAP packages we publish for testing in our environments, we need to pin the deb packages above those from LEAP. Issue #415.