### PR TITLE
Ensures leap packages preferences snippets are removed

### DIFF
--- a/manifests/apt/preferences.pp
+++ b/manifests/apt/preferences.pp
@@ -12,4 +12,11 @@ class pixelated::apt::preferences {
     pin      => 'origin "packages.pixelated-project.org"'
   }
 
+  apt::preferences_snippet { ['soledad-server',
+    'soledad-common',
+    'soledad-client',
+    'leap-keymanager',
+    'leap-auth']:
+      ensure => absent
+  }
 }

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -25,7 +25,7 @@ require 'spec_helper'
       "define apache::vhost::file($content,$mod_security) {}",
       "define apt::sources_list($content='deb url') {}",
       "define apt::apt_conf($source='file url',$refresh_apt='true') {}",
-      "define apt::preferences_snippet($release='stable',$priority='999',$pin='release o=Debian',$package='*') {}",
+      "define apt::preferences_snippet($release='stable',$priority='999',$pin='release o=Debian',$package='*',$ensure='present') {}",
     ] }
 
     it { should contain_class('pixelated::syslog') }

--- a/spec/classes/apt_preferences_spec.rb
+++ b/spec/classes/apt_preferences_spec.rb
@@ -12,12 +12,16 @@ describe 'pixelated::apt::preferences' do
     let(:pre_condition) { [
     "class apt {}",
     "define apt::sources_list($content='deb url') {}",
-    "define apt::preferences_snippet($release='stable',$priority='999',$pin='release o=Debian',$package='*') {}",
+    "define apt::preferences_snippet($release='stable',$priority='999',$pin='release o=Debian',$package='*',$ensure='present') {}",
     ] }
 
   describe 'pixelated packages' do
     it { should contain_apt__preferences_snippet("pixelated").with_pin('origin "packages.pixelated-project.org"')}
     it { should contain_apt__preferences_snippet("pixelated").with_priority('1000')}
+  end
+
+  %w( soledad-server soledad-client soledad-common leap-keymanager leap-auth).each do | package |
+    it { should contain_apt__preferences_snippet("#{package}").with_ensure('absent')}
   end
 
   %w( python-urllib3 python-requests python-six).each do | package |

--- a/spec/classes/pixelated_spec.rb
+++ b/spec/classes/pixelated_spec.rb
@@ -21,7 +21,7 @@ describe 'pixelated' do
       "define apache::vhost::file($content,$mod_security) {}",
       "define apt::sources_list($content='deb url') {}",
       "define apt::apt_conf($source='file url',$refresh_apt='true') {}",
-      "define apt::preferences_snippet($release='stable',$priority='999',$pin='release o=Debian',$package='*') {}",
+      "define apt::preferences_snippet($release='stable',$priority='999',$pin='release o=Debian',$package='*',$ensure='present') {}",
     ] }
 
     it { should contain_class('pixelated::agent') }

--- a/spec/classes/syslog_spec.rb
+++ b/spec/classes/syslog_spec.rb
@@ -15,7 +15,7 @@ describe 'pixelated::syslog' do
       "define apache::vhost::file($content,$mod_security) {}",
       "define apt::sources_list($content='deb url') {}",
       "define apt::apt_conf($source='file url') {}",
-      "define apt::preferences_snippet($release='stable',$priority='999',$pin='release o=Debian',$package='*') {}",
+      "define apt::preferences_snippet($release='stable',$priority='999',$pin='release o=Debian',$package='*',$ensure='present') {}",
     ] }
 
  


### PR DESCRIPTION
Since pixelated packages will now have precedence by origin, we no
longer need the preferences snippets for specific packages. This is to
ensure these files are removed.
https://github.com/pixelated/project-issues/issues/415