### PR TITLE
[#1022] CircleCI configuration file

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,21 @@
+machine:
+  ruby:
+    version:
+      2.1.8
+  environment:
+    LC_ALL: 'en_US.UTF-8'
+
+dependencies:
+  override:
+    - sudo apt-get install rbenv
+    - rbenv rehash
+    - bundle install
+
+test:
+  override:
+    - bundle exec rake validate
+    - cp .fixtures-latest.yml .fixtures.yml
+    - bundle exec rake spec
+    - cp .fixtures-leap-pinned.yml .fixtures.yml
+    - bundle exec rake spec
+


### PR DESCRIPTION
CircleCI configuration.

The rbenv rehash gem that was being used earlier has been merged into rbenv master now so we don't need to reinstall it.  See - https://github.com/rbenv/rbenv/pull/638

Also, Ruby 2.1.5 is what we were installing with rbenv but only 2.1.8 is available on CircleCI.  The build seems to be fine with it.

